### PR TITLE
fix(parser): make chrome iOS ua match safari iOS ua

### DIFF
--- a/library/src/ua.rs
+++ b/library/src/ua.rs
@@ -84,7 +84,7 @@ impl UserAgent for UA {
 
             // Chrome and Opera on iOS uses a UIWebView of the underlying platform to render content. By stripping the CriOS or OPiOS strings, the useragent parser will alias the user agent to ios_saf for the UIWebView, which is closer to the actual renderer
             let ua_string = Regex::new(
-                r"(?i)((CriOS|OPiOS)\/(\d+)\.(\d+)\.(\d+)\.(\d+)|(FxiOS\/(\d+)\.(\d+))) ",
+                r"(?i)((CriOS|OPiOS)\/(\d+)\.(\d+)\.(\d+)\.(\d+)|(FxiOS\/(\d+)\.(\d+)))[ ]",
             )
             .unwrap()
             .replace(&ua_string, "");

--- a/library/src/ua.rs
+++ b/library/src/ua.rs
@@ -84,7 +84,7 @@ impl UserAgent for UA {
 
             // Chrome and Opera on iOS uses a UIWebView of the underlying platform to render content. By stripping the CriOS or OPiOS strings, the useragent parser will alias the user agent to ios_saf for the UIWebView, which is closer to the actual renderer
             let ua_string = Regex::new(
-                r"(?i)((CriOS|OPiOS)\/(\d+)\.(\d+)\.(\d+)\.(\d+)|(FxiOS\/(\d+)\.(\d+)))",
+                r"(?i)((CriOS|OPiOS)\/(\d+)\.(\d+)\.(\d+)\.(\d+)|(FxiOS\/(\d+)\.(\d+))) ",
             )
             .unwrap()
             .replace(&ua_string, "");


### PR DESCRIPTION
## Issue

On the same iOS device, Chrome and Safari browsers return different polyfills.

## Expectation

Since Chrome on iOS is merely a wrapper around Safari on iOS (i.e., uses the same Webkit browser engine), the same JS features should be available to both browsers, thus the same polyfill should be produced.

## Reproduction

The following two curl requests are identical other than a small change to the UA. The Chrome iOS request includes the `CriOS/129.0.6668.46` string in the middle of the UA. Note that these two requests for `fetch`, a long supported feature on iOS, return different polyfill results. Notably, the Chrome iOS request returns a polyfill for `fetch` when it shouldn't be polyfilled. This suggests that it is misidentifying the browser or browser version.

*Safari iOS*

```
curl "https://polyfill-fastly.io/v3/polyfill.js?version=3.111.0&features=fetch" \
     -H 'User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1'
/*
 * Polyfill service v3.111.0
 * For detailed credits and licence information see https://github.com/fastly/polyfill-service/.
 *
 * Features requested: fetch
 *
*/


/* No polyfills needed for current settings and browser */
```

*Chrome iOS*

```
curl "https://polyfill-fastly.io/v3/polyfill.js?version=3.111.0&features=fetch" \
     -H 'User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/129.0.6668.46 Mobile/15E148 Safari/604.1'

/*
 * Polyfill service v3.111.0
 * For detailed credits and licence information see https://github.com/fastly/polyfill-service/.
 * 
 * Features requested: fetch
 * 
 * - URL, License: CC0-1.0
 * - fetch, License: MIT
*/

...truncated
```

## Cause

I believe the root cause is a [regex](https://github.com/fastly/polyfill-service/blob/main/library/src/ua.rs#L87) that intends to remove the Chrome string (e.g., `CriOS/129.0.6668.46`) to make the UA _look_ like a normal Safari iOS string; however, the regex replace leaves an extra space.

For instance, if passed this UA:

```
Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/129.0.6668.46 Mobile/15E148 Safari/604.1
```

It is normalized to:

```
Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)  Mobile/15E148 Safari/604.1
```

It's subtle, but look for the extra space between `Gecko)` and `Mobile`.

With that UA sanitized, the code attempts to figure out the browser family and version. I think it [should match one regex](https://github.com/fastly/polyfill-service/blob/main/library/src/useragent.rs#L159C47-L159C161), but it actually matches [another](https://github.com/fastly/polyfill-service/blob/main/library/src/useragent.rs#L178). This causes the browser version to be misidentified.

I believe that this can be fixed by updating the initial regex to remove the extra whitespace.